### PR TITLE
Build Configuration & Application Installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ The `:Xbuild` command will build the Xcode project in Vim's working directory.
 If the build is successful, you will see 'OK' in the status line.  Otherwise,
 the command will put you into quickfix mode so you can fix compilation errors.
 
+Running Your Application
+------------------------
+
+The ':Xinstall' command will install a built application. Please note that
+`fruitstrap` is a dependency that must be in your PATH for installing to work.
+A specific fork of `fruitstrap` is required. Others may work, but only the one
+located [here](https://github.com/dylancopeland/fruitstrap) has been tested.
+Currently, installing to the simulator is __not__ supported however adding
+support is in the pipeline.
+
 Navigation
 ----------
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,21 @@ The `:Xbuild` command will build the Xcode project in Vim's working directory.
 If the build is successful, you will see 'OK' in the status line.  Otherwise,
 the command will put you into quickfix mode so you can fix compilation errors.
 
-Running Your Application
+Similar to [clang_complete](https://github.com/Rip-Rip/clang_complete), a
+configuration file named `.build` must be in your project's root directory to
+be properly built. A build file simply contains switches that are sent to
+`xcodebuild` when building a project. For example, a `.build` file may look
+like this:
+
+```
+-sdk iphoneos6.0
+-configuration Debug
+```
+
+Installing Your Application
 ------------------------
 
-The ':Xinstall' command will install a built application. Please note that
+The `:Xinstall` command will install a built application. Please note that
 `fruitstrap` is a dependency that must be in your PATH for installing to work.
 A specific fork of `fruitstrap` is required. Others may work, but only the one
 located [here](https://github.com/dylancopeland/fruitstrap) has been tested.

--- a/lib/ios/vim/x_commands.rb
+++ b/lib/ios/vim/x_commands.rb
@@ -1,21 +1,63 @@
 module IOS
-  module Vim
-    module XCommands
+    module Vim
+        module XCommands
 
-      def command_Xadd path, targets
-        XcodeprojInterface.instance.add_file(
-          VIM::Buffer.current.name,
-          path,
-          targets.split(/,/)
-        )
-      rescue Exception => e
-        print e.to_s
-      end
+            def command_Xadd path, targets
+                XcodeprojInterface.instance.add_file(
+                    VIM::Buffer.current.name,
+                    path,
+                    targets.split(/,/)
+                )
+            rescue Exception => e
+                print e.to_s
+            end
 
-      def command_Xbuild
-        XcodeBuilder.new.build
-      end
+            def command_Xbuild
+                build_file = File.open("#{Dir.pwd}/.build") 
+                build_params = build_file.read.gsub("\n","  ")
+                XcodeBuilder.new.build(build_params)
+            end
 
+            # Public: Install an iOS application.
+            #
+            # platform - A required value that must be either "device" or
+            #            "simulator". Simulator support is actually not yet
+            #            implemented but will be soon.
+            def command_Xinstall(platform=nil)
+                if (platform.nil?)
+                    # A platform was not supplied. Notify the user that a valid
+                    # platform must be supplied.
+                    VIM.command('echo "A platform (\"device\" or \"simulator\") must be supplied."')
+                    return
+                elsif (platform.casecmp("device") || platform.casecmp("simulator"))
+                    # Determine where the application bundle is.
+                    platform_folder = platform.casecmp("device") ? "iphoneos" : "iphonesimulator"
+
+                    # Retrive the path to the ARM application bundle.
+                    app_path = app_in_directory("#{Dir.pwd}/build/Debug-#{platform_folder}/")
+
+                    # Install the application to a connected device.
+                    XcodeBuilder.new.install(app_path, platform)
+                end
+            end
+
+            def command_Xdebug(platform=nil)
+
+                if (platform.casecmp("device"))
+                    app_path = app_in_directory("#{Dir.pwd}/build/Debug-iphoneos/")
+                    XcodeRunner.new.debug(app_path)
+                end
+            end
+
+            private
+
+            def app_in_directory(directory)
+                Dir.foreach(directory) do |item|
+                    if File.extname(item) == ".app"
+                        return "#{directory}/#{item}"
+                    end
+                end
+            end
+        end
     end
-  end
 end

--- a/lib/ios/vim/x_commands.rb
+++ b/lib/ios/vim/x_commands.rb
@@ -13,8 +13,13 @@ module IOS
             end
 
             def command_Xbuild
-                build_file = File.open("#{Dir.pwd}/.build") 
-                build_params = build_file.read.gsub("\n","  ")
+                begin
+                    build_file = File.open("#{Dir.pwd}/.build") 
+                    build_params = build_file.read.gsub("\n","  ")
+                rescue
+                    build_params = nil
+                end
+
                 XcodeBuilder.new.build(build_params)
             end
 

--- a/lib/ios/vim/xcode_builder.rb
+++ b/lib/ios/vim/xcode_builder.rb
@@ -8,9 +8,9 @@ module IOS
         @shell_command_runner = shell_command_runner
       end
 
-      def build
+      def build(params)
         VIM.command('echo "Building... "')
-        run_build
+        run_build(params)
         if build_failed?
           start_quickfix_mode
         else
@@ -18,10 +18,23 @@ module IOS
         end
       end
 
-      def run_build
-        (_, @output) = @shell_command_runner.run 'xcodebuild 2>&1'
+      def run_build(params)
+        build_cmd = "xcodebuild #{params} 2>&1"
+        (_, @output) = @shell_command_runner.run build_cmd
       end
-      private :run_build
+
+      def install(path, platform)
+        VIM.command('echo "Installing..."')
+        run_install_device(path)
+        VIM.command('echon "Done!"')
+      end
+
+      def run_install_device(path)
+        run_cmd = "fruitstrap install --bundle #{path}"
+        (_, @output) = @shell_command_runner.run(run_cmd)
+     end
+
+     private :run_build
 
       def build_failed?
         @output =~/\n\*\* BUILD FAILED \*\*/

--- a/lib/ios/vim/xcode_builder.rb
+++ b/lib/ios/vim/xcode_builder.rb
@@ -8,7 +8,7 @@ module IOS
         @shell_command_runner = shell_command_runner
       end
 
-      def build(params)
+      def build(params=nil)
         VIM.command('echo "Building... "')
         run_build(params)
         if build_failed?

--- a/lib/ios/vim/xcode_builder.rb
+++ b/lib/ios/vim/xcode_builder.rb
@@ -1,58 +1,68 @@
 require 'tempfile'
 
 module IOS
-  module Vim
+    module Vim
 
-    class XcodeBuilder
-      def initialize(shell_command_runner = ShellCommandRunner.new)
-        @shell_command_runner = shell_command_runner
-      end
+        class XcodeBuilder
+            def initialize(shell_command_runner = ShellCommandRunner.new)
+                @shell_command_runner = shell_command_runner
+            end
 
-      def build(params=nil)
-        VIM.command('echo "Building... "')
-        run_build(params)
-        if build_failed?
-          start_quickfix_mode
-        else
-          VIM.command('echon "OK"')
+            def build(params=nil)
+                VIM.command('echo "Building... "')
+                run_build(params)
+                if build_failed?
+                    start_quickfix_mode
+                else
+                    VIM.command('echon "OK"')
+                end
+            end
+
+            def run_build(params)
+                if (params)
+                    params = params + ' '
+                end
+                build_cmd = "xcodebuild #{params}2>&1"
+
+                (_, @output) = @shell_command_runner.run build_cmd
+            end
+
+            def install(path, platform)
+                VIM.command('echo "Installing... "')
+                run_install_device(path)
+                if install_failed?
+                    VIM.command('echon "Failed"')
+                else
+                    VIM.command('echon "OK"')
+                end
+            end
+
+            def run_install_device(path)
+                run_cmd = "fruitstrap install --bundle #{path}"
+                (_, @output) = @shell_command_runner.run(run_cmd)
+            end
+
+            private :run_build
+
+            def build_failed?
+                @output =~/\n\*\* BUILD FAILED \*\*/
+            end
+
+            def install_failed?
+                @output =~/\nAMDeviceInstallApplication failed: -402620393/
+            end
+
+            private :build_failed?
+            private :install_failed?
+
+            def start_quickfix_mode
+                tmpfile = Tempfile.new('xcodebuild-errors')
+                tmpfile.write @output
+                tmpfile.close
+                VIM.command "cfile #{tmpfile.path}"
+            end
+            private :start_quickfix_mode
         end
-      end
 
-      def run_build(params)
-          if (params)
-              params = params + ' '
-          end
-          build_cmd = "xcodebuild #{params}2>&1"
-          
-          (_, @output) = @shell_command_runner.run build_cmd
-      end
-
-      def install(path, platform)
-        VIM.command('echo "Installing..."')
-        run_install_device(path)
-        VIM.command('echon "Done!"')
-      end
-
-      def run_install_device(path)
-        run_cmd = "fruitstrap install --bundle #{path}"
-        (_, @output) = @shell_command_runner.run(run_cmd)
-     end
-
-     private :run_build
-
-      def build_failed?
-        @output =~/\n\*\* BUILD FAILED \*\*/
-      end
-      private :build_failed?
-
-      def start_quickfix_mode
-        tmpfile = Tempfile.new('xcodebuild-errors')
-        tmpfile.write @output
-        tmpfile.close
-        VIM.command "cfile #{tmpfile.path}"
-      end
-      private :start_quickfix_mode
     end
-
-  end
 end

--- a/lib/ios/vim/xcode_builder.rb
+++ b/lib/ios/vim/xcode_builder.rb
@@ -19,8 +19,12 @@ module IOS
       end
 
       def run_build(params)
-        build_cmd = "xcodebuild #{params} 2>&1"
-        (_, @output) = @shell_command_runner.run build_cmd
+          if (params)
+              params = params + ' '
+          end
+          build_cmd = "xcodebuild #{params}2>&1"
+          
+          (_, @output) = @shell_command_runner.run build_cmd
       end
 
       def install(path, platform)

--- a/spec/ios/vim/xcode_builder_spec.rb
+++ b/spec/ios/vim/xcode_builder_spec.rb
@@ -11,12 +11,12 @@ describe IOS::Vim::XcodeBuilder do
 
   it 'tells us it is building' do
     VIM.should_receive(:command).with('echo "Building... "')
-    subject.build
+    subject.build(nil)
   end
 
   it 'runs xcodebuild' do
     runner.should_receive(:run).with('xcodebuild 2>&1')
-    subject.build
+    subject.build(nil)
   end
 
   context 'when xcodebuild indicates success' do
@@ -24,7 +24,7 @@ describe IOS::Vim::XcodeBuilder do
 
     it 'tells us "OK"' do
       VIM.should_receive(:command).with('echon "OK"')
-      subject.build
+      subject.build(nil)
     end
   end
 
@@ -38,22 +38,22 @@ describe IOS::Vim::XcodeBuilder do
 
     it 'does not tell us "OK"' do
       VIM.should_not_receive(:command).with('echon "OK"')
-      subject.build
+      subject.build(nil)
     end
 
     it 'writes the output to a temporary file' do
       tmpfile.should_receive(:write).with(xcodebuild_output)
-      subject.build
+      subject.build(nil)
     end
 
     it 'closes the temporary file' do
       tmpfile.should_receive(:close)
-      subject.build
+      subject.build(nil)
     end
 
     it 'starts quickfix mode with the temporary file' do
       VIM.should_receive(:command).with('cfile /abc')
-      subject.build
+      subject.build(nil)
     end
   end
 

--- a/spec/ios/vim/xcode_builder_spec.rb
+++ b/spec/ios/vim/xcode_builder_spec.rb
@@ -11,12 +11,12 @@ describe IOS::Vim::XcodeBuilder do
 
   it 'tells us it is building' do
     VIM.should_receive(:command).with('echo "Building... "')
-    subject.build(nil)
+    subject.build
   end
 
   it 'runs xcodebuild' do
     runner.should_receive(:run).with('xcodebuild 2>&1')
-    subject.build(nil)
+    subject.build
   end
 
   context 'when xcodebuild indicates success' do
@@ -24,7 +24,7 @@ describe IOS::Vim::XcodeBuilder do
 
     it 'tells us "OK"' do
       VIM.should_receive(:command).with('echon "OK"')
-      subject.build(nil)
+      subject.build
     end
   end
 
@@ -38,22 +38,22 @@ describe IOS::Vim::XcodeBuilder do
 
     it 'does not tell us "OK"' do
       VIM.should_not_receive(:command).with('echon "OK"')
-      subject.build(nil)
+      subject.build
     end
 
     it 'writes the output to a temporary file' do
       tmpfile.should_receive(:write).with(xcodebuild_output)
-      subject.build(nil)
+      subject.build
     end
 
     it 'closes the temporary file' do
       tmpfile.should_receive(:close)
-      subject.build(nil)
+      subject.build
     end
 
     it 'starts quickfix mode with the temporary file' do
       VIM.should_receive(:command).with('cfile /abc')
-      subject.build(nil)
+      subject.build
     end
   end
 

--- a/spec/ios/vim/xcode_builder_spec.rb
+++ b/spec/ios/vim/xcode_builder_spec.rb
@@ -3,58 +3,88 @@ require 'ios/vim'
 module VIM; end
 
 describe IOS::Vim::XcodeBuilder do
-  let(:runner) {double :run => [0, ""]}
-  subject {IOS::Vim::XcodeBuilder.new runner}
-  before {VIM.stub(:command)}
+    let(:runner) {double :run => [0, ""]}
+    subject {IOS::Vim::XcodeBuilder.new runner}
+    before {VIM.stub(:command)}
 
-  it {should respond_to(:build)}
+    it {should respond_to(:build)}
 
-  it 'tells us it is building' do
-    VIM.should_receive(:command).with('echo "Building... "')
-    subject.build
-  end
-
-  it 'runs xcodebuild' do
-    runner.should_receive(:run).with('xcodebuild 2>&1')
-    subject.build
-  end
-
-  context 'when xcodebuild indicates success' do
-    before {runner.stub(:run).and_return [0, ""]}
-
-    it 'tells us "OK"' do
-      VIM.should_receive(:command).with('echon "OK"')
-      subject.build
-    end
-  end
-
-  context 'when xcodebuild output includes "\\n** BUILD FAILED **"' do
-    let(:xcodebuild_output) {"flobb \n** BUILD FAILED ** \n "}
-    let(:tmpfile) {double :write => nil, :close => nil, :path => "/abc"}
-    before do
-      Tempfile.stub(:new).and_return tmpfile
-      runner.stub(:run).and_return [0, xcodebuild_output]
+    it 'tells us it is building' do
+        VIM.should_receive(:command).with('echo "Building... "')
+        subject.build
     end
 
-    it 'does not tell us "OK"' do
-      VIM.should_not_receive(:command).with('echon "OK"')
-      subject.build
+    it 'runs xcodebuild' do
+        runner.should_receive(:run).with('xcodebuild 2>&1')
+        subject.build
     end
 
-    it 'writes the output to a temporary file' do
-      tmpfile.should_receive(:write).with(xcodebuild_output)
-      subject.build
+    context 'when xcodebuild indicates success' do
+        before {runner.stub(:run).and_return [0, ""]}
+
+        it 'tells us "OK"' do
+            VIM.should_receive(:command).with('echon "OK"')
+            subject.build
+        end
     end
 
-    it 'closes the temporary file' do
-      tmpfile.should_receive(:close)
-      subject.build
+    context 'when xcodebuild output includes "\\n** BUILD FAILED **"' do
+        let(:xcodebuild_output) {"flobb \n** BUILD FAILED ** \n "}
+        let(:tmpfile) {double :write => nil, :close => nil, :path => "/abc"}
+        before do
+            Tempfile.stub(:new).and_return tmpfile
+            runner.stub(:run).and_return [0, xcodebuild_output]
+        end
+
+        it 'does not tell us "OK"' do
+            VIM.should_not_receive(:command).with('echon "OK"')
+            subject.build
+        end
+
+        it 'writes the output to a temporary file' do
+            tmpfile.should_receive(:write).with(xcodebuild_output)
+            subject.build
+        end
+
+        it 'closes the temporary file' do
+            tmpfile.should_receive(:close)
+            subject.build
+        end
+
+        it 'starts quickfix mode with the temporary file' do
+            VIM.should_receive(:command).with('cfile /abc')
+            subject.build
+        end
+
     end
 
-    it 'starts quickfix mode with the temporary file' do
-      VIM.should_receive(:command).with('cfile /abc')
-      subject.build
+    it {should respond_to(:install)}
+
+    it 'tells us it is installing' do
+        VIM.should_receive(:command).with('echo "Installing... "')
+        subject.install(nil, nil)
     end
-  end
+
+    context 'when fruitstrap indicates success' do
+        before {runner.stub(:run).and_return [0, ""]}
+
+        it 'tells us "OK"' do
+            VIM.should_receive(:command).with('echon "OK"')
+            subject.install(nil, nil)
+        end
+    end
+
+    context 'when fruitstrap output includes "AMDeviceInstallApplication failed"' do
+        let(:fruitstrap_output) {"\nAMDeviceInstallApplication failed: -402620393"}
+
+        before do
+            runner.stub(:run).and_return [0, fruitstrap_output]
+        end
+
+        it 'does not tell us "OK"' do
+            VIM.should_not_receive(:command).with('echon "OK"')
+            subject.install(nil, nil)
+        end
+    end
 
 end


### PR DESCRIPTION
These commits have added build configuration and a new Vim command for installing a built application to a device. The changes are outlined in in `README.md` however I'll briefly outline them here:

**Build Configuration**
A `.build` file in a project's root directory will be used to pass switches to `xcodebuild` when building. I'm not sure if a "selected" configuration and scheme is stored anywhere in an `xcodeproj`, but if it is, I'll definitely look into using this instead.

**Installing**
Using `fruitstrap`, built applications can be installed to a device using `:Xinstall device`. Right now, only devices are supported but I'm going to add simulator support soon.
